### PR TITLE
Add podspec file

### DIFF
--- a/AMRAudioSwift.podspec
+++ b/AMRAudioSwift.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name = "AMRAudioSwift"
+  spec.version = "0.2.3"
+  spec.summary = "A useful tool to encode or decode audio between AMR and WAVE."
+
+  spec.homepage = "https://github.com/teambition/AMRAudioSwift"
+  spec.license = { :type => "MIT", :file => "LICENSE.md" }
+  spec.author = { "Teambition" => "dev@teambition.com" }
+  
+  spec.swift_version = '5.0'
+  spec.platform = :ios
+  spec.ios.deployment_target = "10.0"
+  
+  spec.source = { :git => "https://github.com/teambition/AMRAudioSwift.git", :tag => "#{spec.version}" }
+  spec.source_files = "AMRAudioSwift/**/*.{h,m,swift}"
+  spec.ios.vendored_library = 'AMRAudioSwift/**/*.{a}'
+end

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Specify "AMRAudioSwift" in your ```Cartfile```:
 github "teambition/AMRAudioSwift"
 ```
 
+### Cocoapods
+Specify "AMRAudioSwift" in your ```Podfile``` with the git url:
+
+Note: The use of the git url can be removed when this library is published to Cocoapods.
+```
+pod 'AMRAudioSwift', :git => 'https://github.com/teambition/AMRAudioSwift.git'
+```
+
 ### Usage
 ####  Configuration
 ```swift


### PR DESCRIPTION
Add a podspec file to support Cocoapods.

I don't plan on publishing this to Cocoapods, I'll leave it up to the repo owners to do that if they'd like too.
But at the very least Cocoapod users are now able to use this library like so:
`pod 'AMRAudioSwift', :git => 'https://github.com/teambition/AMRAudioSwift.git'`
